### PR TITLE
Add cityscapes 34 support

### DIFF
--- a/download_scripts/mseg_apply_relabeling.sh
+++ b/download_scripts/mseg_apply_relabeling.sh
@@ -31,6 +31,11 @@ echo "Apply re-labeling to cityscapes-19-relabeled"
 python -u $REPO_ROOT/mseg/label_preparation/mseg_write_relabeled_segments.py \
 	--num_processes $NUM_CORES_TO_USE --dataset_to_relabel cityscapes-19
 
+echo "Apply re-labeling to cityscapes-34-relabeled"
+
+python -u $REPO_ROOT/mseg/label_preparation/mseg_write_relabeled_segments.py \
+	--num_processes $NUM_CORES_TO_USE --dataset_to_relabel cityscapes-34
+
 echo "Apply re-labeling to coco-panoptic-133"
 
 python -u $REPO_ROOT/mseg/label_preparation/mseg_write_relabeled_segments.py \

--- a/mseg/label_preparation/mseg_write_relabeled_segments.py
+++ b/mseg/label_preparation/mseg_write_relabeled_segments.py
@@ -95,7 +95,7 @@ def get_unique_mask_identifiers(
 		segmentid = annot_fname.split('_')[-1]
 		fname_parent = data_split
 
-	elif dname in ['cityscapes-19', 'cityscapes-19-relabeled']:
+	elif dname in ['cityscapes-19', 'cityscapes-19-relabeled', 'cityscapes-34', 'cityscapes-34-relabeled']:
 		# e.g seqfrankfurt_frankfurt_000000_013942_leftImg8bit_28.jpg
 		fname_stem = '_'.join(annot_fname.split('_')[1:-1])
 		segmentid = annot_fname.split('_')[-1]

--- a/mseg/taxonomy/taxonomy_converter.py
+++ b/mseg/taxonomy/taxonomy_converter.py
@@ -92,7 +92,7 @@ class TaxonomyConverter:
 		self._build_universal_tax()
 		self.num_uclasses = len(self.uid2uname) - 1 # excluding ignored label（id=255)
 		# 255 is a privileged class index and must not be used elsewhere
-		assert (self.num_uclasses < 255)
+		assert (self.num_uclasses < 256)
 
 		self.dataset_classnames = {d: load_class_names(d) for d in (self.train_datasets + self.test_datasets)}
 

--- a/tests/verify_all_relabeled_segments.py
+++ b/tests/verify_all_relabeled_segments.py
@@ -354,7 +354,7 @@ def main(args):
 	"""
 	We use the MSeg dataroot explicitly, as specified in mseg/utils/dataset_config.py
 	"""
-	for dname in [
+	dnames_to_verify = [
 		'ade20k-150',
 		'bdd',
 		'coco-panoptic-133',
@@ -363,7 +363,8 @@ def main(args):
 		# Can't do this for the following two since masks overlap
 		# 'cityscapes-19',
 		# 'idd-39',
-	]:
+	]
+	for dname in dnames_to_verify:
 		task = get_relabeling_task(dname)
 		print(f'Completing task:')
 		print(f'\t{task.orig_dname}')
@@ -381,6 +382,7 @@ def main(args):
 			task.update_records, 
 			task.require_strict_boundaries
 		)
+	print('Verifed relabeling for: ', dnames_to_verify)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Change assertion: from <255 to <256 in TaxonomyConverter, to allow one more class in unified taxonomy
- Explicitly dump relabeled cityscapes 34 to disk, so that verification wont halt there.
- Add more informative message that all checks have passed, dataset ready for training and testing