### PR TITLE
Fixes for dataset path verification script

### DIFF
--- a/mseg/utils/mask_utils.py
+++ b/mseg/utils/mask_utils.py
@@ -435,8 +435,8 @@ def highlight_binary_mask(
 	if img_rgb is None:
 		img_rgb = np.ones((img_h, img_w, 3), dtype=np.uint8) * 255
 
-	assert label_mask.dtype in [np.uint8, np.uint16, np.int32, np.uint32, np.int64], 'Label map is not composed of integers.'
-	assert img_rgb.dtype in [np.uint8, np.uint16]
+	assert np.issubdtype(label_mask.dtype, np.integer), 'Label map is not composed of integers.'
+	assert np.issubdtype(img_rgb.dtype, np.integer)
 	our_colormap = colormap(rgb=True)
 
 	# np.unique will always sort the values
@@ -768,8 +768,8 @@ def convert_instance_img_to_mask_img(
 	if img_rgb is None:
 		img_rgb = np.ones((img_h, img_w, 3), dtype=np.uint8) * 255
 
-	assert instance_img.dtype in [np.uint8, np.uint16, np.int32, np.uint32, np.int64], 'Label map is not composed of integers.'
-	assert img_rgb.dtype in [np.uint8, np.uint16]
+	assert np.issubdtype(instance_img.dtype, np.integer), 'Label map is not composed of integers.'
+	assert np.issubdtype(img_rgb.dtype, np.integer)
 	our_colormap = colormap(rgb=True)
 	num_unique_colors = our_colormap.shape[0]
 	# np.unique will always sort the values
@@ -926,7 +926,7 @@ def get_np_mode(x: np.ndarray) -> int:
 		Returns:
 		-	mode of array values (integer)
 	"""
-	assert x.dtype in [np.uint8, np.int16, np.int32, np.int64]
+	assert np.issubdtype(x.dtype, np.integer)
 	counts = np.bincount(x)
 	return np.argmax(counts)
 

--- a/mseg/utils/mask_utils.py
+++ b/mseg/utils/mask_utils.py
@@ -964,7 +964,10 @@ def get_mask_from_polygon(polygon, img_h, img_w):
 
 	# include outline
 	# a drawer to draw into the image
-	ImageDraw.Draw(mask_img).polygon(polygon, outline=1, fill=1) 
+	if len(set([y for (x,y) in polygon])) == 1:
+		ImageDraw.Draw(mask_img).line(polygon, fill=1)
+	else:
+		ImageDraw.Draw(mask_img).polygon(polygon, outline=1, fill=1) 
 	mask = np.array(mask_img)
 	return mask
 
@@ -991,8 +994,3 @@ def get_most_populous_class(segment_mask: np.array, label_map: np.ndarray):
 	class_indices = label_map[segment_mask.nonzero()]
 	class_mode_idx = get_np_mode(class_indices)
 	return class_mode_idx
-
-
-
-
-


### PR DESCRIPTION
Check if polygon is degenerate, i.e. all vertices are on a horizontal line. In that case, use ImageDraw.Draw.line instead.

Generalize type assertions by checking for subtype of np.integer instead of using a list of some integer types.