### PR TITLE
Provide access to classnames of dynamically built naive taxonomy

### DIFF
--- a/mseg/taxonomy/naive_taxonomy_converter.py
+++ b/mseg/taxonomy/naive_taxonomy_converter.py
@@ -81,7 +81,10 @@ class NaiveTaxonomyConverter(TaxonomyConverter):
                     id += 1
 
     def get_naive_taxonomy_classnames(self) -> List[Optional[str]]:
-        """
+        """Get a list of ordered classes in the naive taxonomy.
+
+        The logits of a model's predictions at each pixel should also be ordered accordingly.
+
         Returns:
             classnames: order list of classnames in the taxonomy. The ignore index is filled with `None`.
         """

--- a/mseg/taxonomy/naive_taxonomy_converter.py
+++ b/mseg/taxonomy/naive_taxonomy_converter.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-from typing import List, Mapping, Optional,Tuple
+from typing import List, Mapping, Optional, Tuple
 
 import torch.nn as nn
 
@@ -38,7 +38,9 @@ class NaiveTaxonomyConverter(TaxonomyConverter):
         # Inverse -- find universal index from universal name.
         self.uname2uid = {}
 
-        self.dataset_classnames = {d: names_utils.load_class_names(d) for d in (self.train_datasets + self.test_datasets)}
+        self.dataset_classnames = {
+            d: names_utils.load_class_names(d) for d in (self.train_datasets + self.test_datasets)
+        }
         self._build_universal_tax()
 
         # including ignored label（id=255), since total id > 255. (note previously it's -1)
@@ -66,7 +68,7 @@ class NaiveTaxonomyConverter(TaxonomyConverter):
                 lowercase = c.lower()
 
                 if lowercase in self.uname2uid.keys():
-                    #print(f'class {c} already in, lowercase is {lowercase}')
+                    # print(f'class {c} already in, lowercase is {lowercase}')
                     continue
 
                 # otherwise, `lowercase` is not found in `self.uname2uid` yet, so we'll make a new entry.
@@ -83,7 +85,7 @@ class NaiveTaxonomyConverter(TaxonomyConverter):
         Returns:
             classnames: order list of classnames in the taxonomy. The ignore index is filled with `None`.
         """
-        num_classes = max(self.uid2uname.keys()) + 1 # can't use len, since `255' is a missing key.
+        num_classes = max(self.uid2uname.keys()) + 1  # can't use len, since `255' is a missing key.
         classnames = [None] * num_classes
 
         for uid, uname in self.uid2uname.items():
@@ -113,7 +115,7 @@ class NaiveTaxonomyConverter(TaxonomyConverter):
         id2uid_map[self.ignore_label] = self.ignore_label
         return id2uid_map
 
-    def _transform_u2d(self, dataset: str) -> List[Tuple[int,int]]:
+    def _transform_u2d(self, dataset: str) -> List[Tuple[int, int]]:
         """Explicitly for inference on our test datasets. Store correspondences
         between universal_taxonomy and test_dataset_taxonomy.
         Lowercase string would be the universal taxonomy classname, if exists.

--- a/mseg/taxonomy/naive_taxonomy_converter.py
+++ b/mseg/taxonomy/naive_taxonomy_converter.py
@@ -1,9 +1,10 @@
 #!/usr/bin/python3
 
-import torch.nn as nn
-from typing import List, Mapping, Tuple
+from typing import List, Mapping, Optional,Tuple
 
-from mseg.utils.names_utils import load_class_names
+import torch.nn as nn
+
+import mseg.utils.names_utils as names_utils
 from mseg.taxonomy.taxonomy_converter import TaxonomyConverter, UNRELABELED_TRAIN_DATASETS, TEST_DATASETS
 
 
@@ -37,7 +38,7 @@ class NaiveTaxonomyConverter(TaxonomyConverter):
         # Inverse -- find universal index from universal name.
         self.uname2uid = {}
 
-        self.dataset_classnames = {d: load_class_names(d) for d in (self.train_datasets + self.test_datasets)}
+        self.dataset_classnames = {d: names_utils.load_class_names(d) for d in (self.train_datasets + self.test_datasets)}
         self._build_universal_tax()
 
         # including ignored label（id=255), since total id > 255. (note previously it's -1)
@@ -63,17 +64,32 @@ class NaiveTaxonomyConverter(TaxonomyConverter):
             classes = self.dataset_classnames[d]
             for c in classes:
                 lowercase = c.lower()
-                if lowercase not in self.uname2uid.keys():
-                    self.uname2uid[lowercase] = id
-                    self.uid2uname[id] = lowercase
+
+                if lowercase in self.uname2uid.keys():
+                    #print(f'class {c} already in, lowercase is {lowercase}')
+                    continue
+
+                # otherwise, `lowercase` is not found in `self.uname2uid` yet, so we'll make a new entry.
+                self.uname2uid[lowercase] = id
+                self.uid2uname[id] = lowercase
+                id += 1
+                # if incremented id is 255, then skip it
+                if id == self.ignore_label:
+                    # skip 255, since want to reserve 255 as ignore_label
                     id += 1
-                    # if incremented id is 255, then skip it
-                    if id == self.ignore_label:
-                        # skip 255, since want to reserve 255 as ignore_label
-                        id += 1
-                else:
-                    # print(f'class {c} already in, lowercase is {lowercase}')
-                    pass
+
+    def get_naive_taxonomy_classnames(self) -> List[Optional[str]]:
+        """
+        Returns:
+            classnames: order list of classnames in the taxonomy. The ignore index is filled with `None`.
+        """
+        num_classes = max(self.uid2uname.keys()) + 1 # can't use len, since `255' is a missing key.
+        classnames = [None] * num_classes
+
+        for uid, uname in self.uid2uname.items():
+            classnames[uid] = uname
+
+        return classnames
 
     def _transform_d2u(self, dataset: str) -> Mapping[int, int]:
         """Transform a training dataset to the universal taxonomy.
@@ -97,7 +113,7 @@ class NaiveTaxonomyConverter(TaxonomyConverter):
         id2uid_map[self.ignore_label] = self.ignore_label
         return id2uid_map
 
-    def _transform_u2d(self, dataset):
+    def _transform_u2d(self, dataset: str) -> List[Tuple[int,int]]:
         """Explicitly for inference on our test datasets. Store correspondences
         between universal_taxonomy and test_dataset_taxonomy.
         Lowercase string would be the universal taxonomy classname, if exists.

--- a/mseg/taxonomy/taxonomy_converter.py
+++ b/mseg/taxonomy/taxonomy_converter.py
@@ -24,12 +24,13 @@ UNRELABELED_TRAIN_DATASETS = [
     "ade20k-150",
     "bdd",
     "cityscapes-19",
-    "cityscapes-34",
     "coco-panoptic-133",
     "idd-39",
     "mapillary-public65",
     "sunrgbd-37",
 ]
+# unrelabeled "cityscapes-34" is not used for training, but it could be, if desired.
+
 RELABELED_TRAIN_DATASETS = [
     "ade20k-150-relabeled",
     "bdd-relabeled",

--- a/tests/test_naive_taxonomy_converter.py
+++ b/tests/test_naive_taxonomy_converter.py
@@ -1,14 +1,9 @@
 #!/usr/bin/python3
 
 import numpy as np
-import pdb
 import torch
 
-from mseg.utils.names_utils import (
-    load_class_names,
-    get_universal_class_names,
-    get_classname_to_dataloaderid_map,
-)
+import mseg.utils.names_utils as names_utils
 from mseg.taxonomy.naive_taxonomy_converter import NaiveTaxonomyConverter
 
 
@@ -18,23 +13,33 @@ def test_constructor() -> None:
 
 
 def test_number_naive_classes() -> None:
-    """ """
+    """
+    316 classes (with 255 being a dummy class), so 315 are mapped to real classnames.
+    """
     ntc = NaiveTaxonomyConverter()
 
-    # exclude the `unlabeled` class
-    assert len(ntc.uname2uid) - 1 == 318
-    assert len(ntc.uid2uname) - 1 == 318
+    # the `unlabeled` class is not included in these dictionaries.
+    assert len(ntc.uname2uid) == 315
+    assert len(ntc.uid2uname) == 315
+
+
+def test_get_naive_taxonomy_classnames() -> None:
+    """Ensure that the logits space (316 classes) has the right size, and is ordered as expected."""
+    ntc = NaiveTaxonomyConverter()
+    ordered_classnames = ntc.get_naive_taxonomy_classnames()
+    assert len(ordered_classnames) == 316
 
 
 def test_label_transform() -> None:
     """
-    Bring label from training taxonomy (mapillary-public65)
-    to the universal taxonomy.
+    Bring label from training taxonomy (mapillary-public65) to the universal taxonomy.
+    Dummy 4x4 label map from Mapillary Public (65 class) with all "Motorcyclist" GT.
+    We ensure that after remapping, we get GT for "motorcyclist" in the universal taxonomy.
 
-    21 is the motorcyclist class in mapillary-public65
+    21 is the motorcyclist class in mapillary-public65.
     """
     dname = "mapillary-public65"
-    txt_classnames = load_class_names(dname)
+    txt_classnames = names_utils.load_class_names(dname)
     train_idx = txt_classnames.index("Motorcyclist")
     ntc = NaiveTaxonomyConverter()
     # training dataset label
@@ -50,26 +55,26 @@ def test_label_transform() -> None:
     assert np.allclose(u_label.numpy(), gt_u_label)
 
 
-def test_label_transform_unlabeled():
+def test_label_transform_unlabeled() -> None:
     """
     Make sure 255 stays mapped to 255 at each level (to be ignored in cross-entropy loss).
     """
     IGNORE_LABEL = 255
     dname = "mapillary-public65"
-    txt_classnames = load_class_names(dname)
-    name2id = get_classname_to_dataloaderid_map(dname, include_ignore_idx_cls=True)
+    txt_classnames = names_utils.load_class_names(dname)
+    name2id = names_utils.get_classname_to_dataloaderid_map(dname, include_ignore_idx_cls=True)
     train_idx = name2id["unlabeled"]
 
     ntc = NaiveTaxonomyConverter()
-    # training dataset label
-    traind_label = torch.ones(4, 4) * train_idx
-    traind_label = traind_label.type(torch.LongTensor)
+    # training dataset labels (`traind')
+    traind_label_map = torch.ones(4, 4) * train_idx
+    traind_label_map = traind_label_map.type(torch.LongTensor)
 
     # Get back the universal label
-    u_label = ntc.transform_label(traind_label, dname)
+    u_label_map = ntc.transform_label(traind_label_map, dname)
     u_idx = IGNORE_LABEL
-    gt_u_label = np.ones((4, 4)).astype(np.int64) * u_idx
-    assert np.allclose(u_label.numpy(), gt_u_label)
+    gt_u_label_map = np.ones((4, 4)).astype(np.int64) * u_idx
+    assert np.allclose(u_label_map.numpy(), gt_u_label_map)
 
 
 def test_transform_predictions_test() -> None:
@@ -82,26 +87,31 @@ def test_transform_predictions_test() -> None:
     For Camvid, universal probabilities for `person',`bicycle'
     should both go into the 'Bicyclist' class.
 
-    320 universal classes here, instead of 194.
+    This test ensures that:
+        - universal "road" probs go to camvid "Road" probs.
+        - universal "sky" probs go to camvid "Sky" probs.
+
+    316 universal classes here, instead of 194.
     """
     ntc = NaiveTaxonomyConverter()
+
     dog_uidx = ntc.uname2uid["dog"]  # not in camvid
     road_uidx = ntc.uname2uid["road"]
     sky_uidx = ntc.uname2uid["sky"]
 
-    input = np.zeros((320, 2, 3))
-    input[dog_uidx, :, 0] = 1.0  # far left col is dog
-    input[road_uidx, :, 1] = 1.0  # middle col is road
-    input[sky_uidx, :, 2] = 1.0  # far right col is sky
+    # represents logits
+    logits = torch.zeros((316, 2, 3))
+    logits[dog_uidx, :, 0] = 1.0  # far left col is dog
+    logits[road_uidx, :, 1] = 1.0  # middle col is road
+    logits[sky_uidx, :, 2] = 1.0  # far right col is sky
 
-    input = torch.from_numpy(input)
-    input = input.unsqueeze(0).float()  # CHW -> NCHW
-    assert input.shape == (1, 320, 2, 3)
+    logits = logits.unsqueeze(0).float()  # CHW -> NCHW
+    assert logits.shape == (1, 316, 2, 3)
 
     test_dname = "camvid-11"
-    camvid_classnames = load_class_names(test_dname)
+    camvid_classnames = names_utils.load_class_names(test_dname)
 
-    output = ntc.transform_predictions_test(input, test_dname)
+    output = ntc.transform_predictions_test(logits, test_dname)
     output = output.squeeze()  # NCHW -> CHW
 
     weight_matrix = ntc.convs[test_dname].weight.squeeze().numpy()
@@ -131,11 +141,11 @@ def test_constructor_types() -> None:
 def test_label_mapping_arrs() -> None:
     """ """
     ntc = NaiveTaxonomyConverter()
-    train_idx = load_class_names("ade20k-150").index("road")
+    train_idx = names_utils.load_class_names("ade20k-150").index("road")
     u_idx = ntc.uname2uid["road"]
     assert ntc.label_mapping_arr_dict["ade20k-150"][train_idx] == u_idx
 
-    train_idx = load_class_names("mapillary-public65").index("Bird")
+    train_idx = names_utils.load_class_names("mapillary-public65").index("Bird")
     u_idx = ntc.uname2uid["bird"]
     assert ntc.label_mapping_arr_dict["mapillary-public65"][train_idx] == u_idx
 


### PR DESCRIPTION
- Logits space of "naive-merge" model should have had 316 classes, not 320 (cityscapes-34 was erroneously included in list of train datasets)
- Style fixes (return early instead of nesting)